### PR TITLE
Changing usage for commands that support multiple options

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"strings"
 	"sync"
 
 	h "github.com/j2udevelopment/kruise/pkg/helm"
 	u "github.com/j2udevelopment/kruise/pkg/utils"
+	t "github.com/j2udevelopment/kruise/tpl"
 	"github.com/spf13/cobra"
 )
 
@@ -80,48 +80,18 @@ var deleteCmd = &cobra.Command{
 				}()
 			}
 		}
-
-		for i := 0; i < len(args); i++ {
-			deployment := strings.ToLower(args[i])
-			switch {
-			case deployment == "jaeger":
-				go func() {
-					h.Uninstall(jaegerDeployment)
-					wg.Done()
-				}()
-			case deployment == "kafka":
-				go func() {
-					h.Uninstall(kafkaDeployment)
-					wg.Done()
-				}()
-			case deployment == "mongodb":
-				go func() {
-					h.Uninstall(mongodbDeployment)
-					wg.Done()
-				}()
-			case deployment == "mysql":
-				go func() {
-					h.Uninstall(mysqlDeployment)
-					wg.Done()
-				}()
-			case deployment == "postgresql":
-				go func() {
-					h.Uninstall(postgresqlDeployment)
-					wg.Done()
-				}()
-			case deployment == "prometheus-operator":
-				go func() {
-					h.Uninstall(prometheusOperatorDeployment)
-					wg.Done()
-				}()
-			}
-		}
 		wg.Wait()
 	},
 }
 
 func init() {
+	var wrapper = u.CommandWrapper{
+		Cmd:  deleteCmd,
+		Opts: deleteOpts,
+	}
 	rootCmd.AddCommand(deleteCmd)
+	deleteCmd.SetUsageTemplate(t.UsageTemplate())
+	deleteCmd.SetUsageFunc(t.UsageFunc(wrapper))
 	deleteCmd.PersistentFlags().StringVarP(&chartNamespace, "namespace", "n", "", "Override the namespace for the specified deployments")
 	deleteCmd.PersistentFlags().StringVar(&jaegerDeployment.Namespace, "jaeger-namespace", "observability", "Override the Jaeger namespace")
 	deleteCmd.PersistentFlags().StringVar(&kafkaDeployment.Namespace, "kafka-namespace", "kafka", "Override the Kafka namespace")

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,52 +1,117 @@
 package cmd
 
 import (
-	"github.com/j2udevelopment/kruise/pkg/helm"
-	"github.com/spf13/cobra"
 	"strings"
 	"sync"
+
+	h "github.com/j2udevelopment/kruise/pkg/helm"
+	u "github.com/j2udevelopment/kruise/pkg/utils"
+	"github.com/spf13/cobra"
 )
+
+var deleteOpts = []u.Option{
+	{
+		Arguments:   "jaeger",
+		Description: "Deletes Jaeger from your Kubernetes Cluster",
+	},
+	{
+		Arguments:   "kafka",
+		Description: "Deletes Kafka from your Kubernetes Cluster",
+	},
+	{
+		Arguments:   "mongodb, mongo",
+		Description: "Deletes MongoDB from your Kubernetes Cluster",
+	},
+	{
+		Arguments:   "mysql",
+		Description: "Deletes MySQL from your Kubernetes Cluster",
+	},
+	{
+		Arguments:   "postgresql, postgres",
+		Description: "Deletes PostgreSQL from your Kubernetes Cluster",
+	},
+	{
+		Arguments:   "prometheus-operator, prom-op",
+		Description: "Deletes Prometheus Operator from your Kubernetes Cluster",
+	},
+}
 
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
 	Use:       "delete",
 	Short:     "Delete the specified options from your Kubernetes cluster",
 	Args:      cobra.MinimumNArgs(1),
-	ValidArgs: []string{"mongodb", "kafka"},
+	ValidArgs: u.CollectValidArgs(deleteOpts),
 	Run: func(cmd *cobra.Command, args []string) {
+		validArgsMap := u.CollectValidArgsMap(deleteOpts)
 		wg := sync.WaitGroup{}
 		wg.Add(len(args))
+		for _, arg := range args {
+			switch {
+			case u.Contains(validArgsMap["jaeger"], arg):
+				go func() {
+					h.Uninstall(jaegerDeployment)
+					wg.Done()
+				}()
+			case u.Contains(validArgsMap["kafka"], arg):
+				go func() {
+					h.Uninstall(kafkaDeployment)
+					wg.Done()
+				}()
+			case u.Contains(validArgsMap["mongodb"], arg):
+				go func() {
+					h.Uninstall(mongodbDeployment)
+					wg.Done()
+				}()
+			case u.Contains(validArgsMap["mysql"], arg):
+				go func() {
+					h.Uninstall(mysqlDeployment)
+					wg.Done()
+				}()
+			case u.Contains(validArgsMap["postgresql"], arg):
+				go func() {
+					h.Uninstall(postgresqlDeployment)
+					wg.Done()
+				}()
+			case u.Contains(validArgsMap["prometheus-operator"], arg):
+				go func() {
+					h.Uninstall(prometheusOperatorDeployment)
+					wg.Done()
+				}()
+			}
+		}
+
 		for i := 0; i < len(args); i++ {
 			deployment := strings.ToLower(args[i])
 			switch {
 			case deployment == "jaeger":
 				go func() {
-					helm.Uninstall(jaegerDeployment)
+					h.Uninstall(jaegerDeployment)
 					wg.Done()
 				}()
 			case deployment == "kafka":
 				go func() {
-					helm.Uninstall(kafkaDeployment)
+					h.Uninstall(kafkaDeployment)
 					wg.Done()
 				}()
 			case deployment == "mongodb":
 				go func() {
-					helm.Uninstall(mongoDeployment)
+					h.Uninstall(mongodbDeployment)
 					wg.Done()
 				}()
 			case deployment == "mysql":
 				go func() {
-					helm.Uninstall(mysqlDeployment)
+					h.Uninstall(mysqlDeployment)
 					wg.Done()
 				}()
 			case deployment == "postgresql":
 				go func() {
-					helm.Uninstall(postgresqlDeployment)
+					h.Uninstall(postgresqlDeployment)
 					wg.Done()
 				}()
 			case deployment == "prometheus-operator":
 				go func() {
-					helm.Uninstall(prometheusOperatorDeployment)
+					h.Uninstall(prometheusOperatorDeployment)
 					wg.Done()
 				}()
 			}
@@ -60,7 +125,7 @@ func init() {
 	deleteCmd.PersistentFlags().StringVarP(&chartNamespace, "namespace", "n", "", "Override the namespace for the specified deployments")
 	deleteCmd.PersistentFlags().StringVar(&jaegerDeployment.Namespace, "jaeger-namespace", "observability", "Override the Jaeger namespace")
 	deleteCmd.PersistentFlags().StringVar(&kafkaDeployment.Namespace, "kafka-namespace", "kafka", "Override the Kafka namespace")
-	deleteCmd.PersistentFlags().StringVar(&mongoDeployment.Namespace, "mongodb-namespace", "mongodb", "Override the MongoDB namespace")
+	deleteCmd.PersistentFlags().StringVar(&mongodbDeployment.Namespace, "mongodb-namespace", "mongodb", "Override the MongoDB namespace")
 	deleteCmd.PersistentFlags().StringVar(&mysqlDeployment.Namespace, "mysql-namespace", "mysql", "Override the MySQL namespace")
 	deleteCmd.PersistentFlags().StringVar(&postgresqlDeployment.Namespace, "postgresql-namespace", "postgresql", "Override the PostgreSQL namespace")
 	deleteCmd.PersistentFlags().StringVar(&prometheusOperatorDeployment.Namespace, "prom-op-namespace", "monitoring", "Override the Prometheus Operator namespace")

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,21 +1,49 @@
 package cmd
 
 import (
+	"sync"
+
 	c "github.com/j2udevelopment/kruise/pkg/config"
-	"github.com/j2udevelopment/kruise/pkg/helm"
+	h "github.com/j2udevelopment/kruise/pkg/helm"
+	u "github.com/j2udevelopment/kruise/pkg/utils"
+	t "github.com/j2udevelopment/kruise/tpl"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"strings"
-	"sync"
 )
+
+var deployOpts = []u.Option{
+	{
+		Arguments:   "jaeger",
+		Description: "Deploys Jaeger to your Kubernetes Cluster",
+	},
+	{
+		Arguments:   "kafka",
+		Description: "Deploys Kafka to your Kubernetes Cluster",
+	},
+	{
+		Arguments:   "mongodb, mongo",
+		Description: "Deploys MongoDB to your Kubernetes Cluster",
+	},
+	{
+		Arguments:   "mysql",
+		Description: "Deploys MySQL to your Kubernetes Cluster",
+	},
+	{
+		Arguments:   "postgresql, postgres",
+		Description: "Deploys PostgreSQL to your Kubernetes Cluster",
+	},
+	{
+		Arguments:   "prometheus-operator, prom-op",
+		Description: "Deploys Prometheus Operator to your Kubernetes Cluster",
+	},
+}
 
 var chartVersion string
 var chartNamespace string
-
 var jaegerDeployment = c.HelmConfig{ReleaseName: "jaeger", ChartPath: "jaegertracing/jaeger"}
 var kafkaDeployment = c.HelmConfig{ReleaseName: "kafka", ChartPath: "bitnami/kafka"}
-var mongoDeployment = c.HelmConfig{ReleaseName: "mongodb", ChartPath: "bitnami/mongodb"}
+var mongodbDeployment = c.HelmConfig{ReleaseName: "mongodb", ChartPath: "bitnami/mongodb"}
 var mysqlDeployment = c.HelmConfig{ReleaseName: "mysql", ChartPath: "bitnami/mysql"}
 var postgresqlDeployment = c.HelmConfig{ReleaseName: "postgresql", ChartPath: "bitnami/postgresql"}
 var prometheusOperatorDeployment = c.HelmConfig{ReleaseName: "prometheus-operator", ChartPath: "prometheus-community/kube-prometheus-stack"}
@@ -25,47 +53,47 @@ var deployCmd = &cobra.Command{
 	Use:       "deploy",
 	Short:     "Deploy the specified options to your Kubernetes cluster",
 	Args:      cobra.MinimumNArgs(1),
-	ValidArgs: []string{"jaeger", "kafka", "mongodb", "mysql", "postgresql", "prometheus-operator"},
+	ValidArgs: u.CollectValidArgs(deployOpts),
 	Run: func(cmd *cobra.Command, args []string) {
+		validArgsMap := u.CollectValidArgsMap(deployOpts)
 		wg := sync.WaitGroup{}
 		wg.Add(len(args))
-		for i := 0; i < len(args); i++ {
-			deployment := strings.ToLower(args[i])
+		for _, arg := range args {
 			switch {
-			case deployment == "jaeger":
+			case u.Contains(validArgsMap["jaeger"], arg):
 				go func() {
 					mapstructure.Decode(viper.GetStringMap("deploy.jaeger"), &jaegerDeployment)
-					helm.Install(jaegerDeployment)
+					h.Install(jaegerDeployment)
 					wg.Done()
 				}()
-			case deployment == "kafka":
+			case u.Contains(validArgsMap["kafka"], arg):
 				go func() {
 					mapstructure.Decode(viper.GetStringMap("deploy.kafka"), &kafkaDeployment)
-					helm.Install(kafkaDeployment)
+					h.Install(kafkaDeployment)
 					wg.Done()
 				}()
-			case deployment == "mongodb":
+			case u.Contains(validArgsMap["mongodb"], arg):
 				go func() {
-					mapstructure.Decode(viper.GetStringMap("deploy.mongodb"), &mongoDeployment)
-					helm.Install(mongoDeployment)
+					mapstructure.Decode(viper.GetStringMap("deploy.mongodb"), &mongodbDeployment)
+					h.Install(mongodbDeployment)
 					wg.Done()
 				}()
-			case deployment == "mysql":
+			case u.Contains(validArgsMap["mysql"], arg):
 				go func() {
 					mapstructure.Decode(viper.GetStringMap("deploy.mysql"), &mysqlDeployment)
-					helm.Install(mysqlDeployment)
+					h.Install(mysqlDeployment)
 					wg.Done()
 				}()
-			case deployment == "postgresql":
+			case u.Contains(validArgsMap["postgresql"], arg):
 				go func() {
 					mapstructure.Decode(viper.GetStringMap("deploy.postgresql"), &postgresqlDeployment)
-					helm.Install(postgresqlDeployment)
+					h.Install(postgresqlDeployment)
 					wg.Done()
 				}()
-			case deployment == "prometheus-operator":
+			case u.Contains(validArgsMap["prometheus-operator"], arg):
 				go func() {
 					mapstructure.Decode(viper.GetStringMap("deploy.prometheus-operator"), &prometheusOperatorDeployment)
-					helm.Install(prometheusOperatorDeployment)
+					h.Install(prometheusOperatorDeployment)
 					wg.Done()
 				}()
 			}
@@ -75,15 +103,21 @@ var deployCmd = &cobra.Command{
 }
 
 func init() {
+	var wrapper = u.CommandWrapper{
+		Cmd:  deployCmd,
+		Opts: deployOpts,
+	}
 	rootCmd.AddCommand(deployCmd)
+	deployCmd.SetUsageTemplate(t.UsageTemplate())
+	deployCmd.SetUsageFunc(t.UsageFunc(wrapper))
 	deployCmd.PersistentFlags().StringVarP(&chartVersion, "version", "v", "", "Override the Helm chart version for the specified deployments")
 	deployCmd.PersistentFlags().StringVarP(&chartNamespace, "namespace", "n", "", "Override the namespace for the specified deployments")
 	deployCmd.PersistentFlags().StringVar(&jaegerDeployment.Version, "jaeger-version", "", "Override the Jaeger Helm chart version")
 	deployCmd.PersistentFlags().StringVar(&jaegerDeployment.Namespace, "jaeger-namespace", "observability", "Override the Jaeger namespace")
 	deployCmd.PersistentFlags().StringVar(&kafkaDeployment.Version, "kafka-version", "", "Override the Kafka Helm chart version")
 	deployCmd.PersistentFlags().StringVar(&kafkaDeployment.Namespace, "kafka-namespace", "kafka", "Override the Kafka namespace")
-	deployCmd.PersistentFlags().StringVar(&mongoDeployment.Version, "mongodb-version", "", "Override the MongoDB Helm chart version")
-	deployCmd.PersistentFlags().StringVar(&mongoDeployment.Namespace, "mongodb-namespace", "mongodb", "Override the MongoDB namespace")
+	deployCmd.PersistentFlags().StringVar(&mongodbDeployment.Version, "mongodb-version", "", "Override the MongoDB Helm chart version")
+	deployCmd.PersistentFlags().StringVar(&mongodbDeployment.Namespace, "mongodb-namespace", "mongodb", "Override the MongoDB namespace")
 	deployCmd.PersistentFlags().StringVar(&mysqlDeployment.Version, "mysql-version", "", "Override the MySQL Helm chart version")
 	deployCmd.PersistentFlags().StringVar(&mysqlDeployment.Namespace, "mysql-namespace", "mysql", "Override the MySQL namespace")
 	deployCmd.PersistentFlags().StringVar(&postgresqlDeployment.Version, "postgresql-version", "", "Override the PostgreSQL Helm chart version")

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -5,11 +5,11 @@ import (
 	"log"
 	"os/exec"
 
-	"github.com/j2udevelopment/kruise/pkg/config"
+	c "github.com/j2udevelopment/kruise/pkg/config"
 )
 
 // ConstructChart function used to initialize Helm chart configuration with default values
-func ConstructChart(helmConfig *config.HelmConfig) {
+func ConstructChart(helmConfig *c.HelmConfig) {
 	if helmConfig.ReleaseName == "" {
 		log.Fatal("You must specify a Helm release name")
 	}
@@ -34,7 +34,7 @@ func ConstructChart(helmConfig *config.HelmConfig) {
 }
 
 // Install function used to install Helm charts in an abstract way
-func Install(helmConfig config.HelmConfig) {
+func Install(helmConfig c.HelmConfig) {
 	helmCheck := exec.Command("command", "-v", "helm")
 	if err := helmCheck.Run(); err != nil {
 		log.Fatal("Helm does not appear to be installed")
@@ -57,7 +57,7 @@ func Install(helmConfig config.HelmConfig) {
 }
 
 // Uninstall function used to uninstall Helm charts in an abstract way
-func Uninstall(helmConfig config.HelmConfig) {
+func Uninstall(helmConfig c.HelmConfig) {
 	helmCheck := exec.Command("command", "-v", "helm")
 	if err := helmCheck.Run(); err != nil {
 		log.Fatal("Helm does not appear to be installed")

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -2,9 +2,10 @@ package helm
 
 import (
 	"fmt"
-	"github.com/j2udevelopment/kruise/pkg/config"
 	"log"
 	"os/exec"
+
+	"github.com/j2udevelopment/kruise/pkg/config"
 )
 
 // ConstructChart function used to initialize Helm chart configuration with default values

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// CommandWrapper is used to wrap the Command struct to support command options
+type CommandWrapper struct {
+	Cmd  *cobra.Command
+	Opts []Option
+}
+
+// Option is used to map an argument to a description and is primarily used for
+// usage templating
+type Option struct {
+	Arguments   string
+	Description string
+}
+
+// Check is an abstraction for common error handling
+func Check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Contains determines whether a string is contained within a slice of strings
+func Contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}
+
+// CollectValidArgs is used to filter a slice of human-readable options into a
+// slice of strings to be used with the Cobra Command ValidArgs slice
+func CollectValidArgs(opts []Option) []string {
+	var collector = []string{}
+	for _, opt := range opts {
+		collector = append(collector, strings.Split(opt.Arguments, ", ")...)
+	}
+	return collector
+}
+
+// CollectValidArgsDict is used as a set to facilitate quickly looking up valid
+// arguments
+func CollectValidArgsDict(args []string) map[string]bool {
+	argsDict := make(map[string]bool)
+	for _, arg := range args {
+		argsDict[arg] = true
+	}
+	return argsDict
+}
+
+// CollectValidArgsMap is used as a set to facilitate quickly looking up valid
+// arguments
+func CollectValidArgsMap(opts []Option) map[string][]string {
+	argsMap := make(map[string][]string)
+	for _, opt := range opts {
+		optArgs := strings.Split(opt.Arguments, ", ")
+		argsMap[optArgs[0]] = optArgs
+	}
+	return argsMap
+}

--- a/tpl/help.go
+++ b/tpl/help.go
@@ -9,7 +9,7 @@ import (
 	"text/template"
 	"unicode"
 
-	"github.com/j2udevelopment/kruise/pkg/utils"
+	u "github.com/j2udevelopment/kruise/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +67,7 @@ Use "{{.Cmd.CommandPath}} [command] --help" for more information about a command
 }
 
 // UsageFunc overrides the default UsageFunc used by Cobra to facilitate showing command options
-func UsageFunc(wrapper utils.CommandWrapper) (f func(*cobra.Command) error) {
+func UsageFunc(wrapper u.CommandWrapper) (f func(*cobra.Command) error) {
 	return func(c *cobra.Command) error {
 		w := tabwriter.NewWriter(os.Stdout, 8, 8, 8, ' ', 0)
 		err := tmpl(w, UsageTemplate(), wrapper)

--- a/tpl/help.go
+++ b/tpl/help.go
@@ -1,0 +1,80 @@
+package tpl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+	"unicode"
+
+	"github.com/j2udevelopment/kruise/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var templateFuncs = template.FuncMap{
+	"trim":                    strings.TrimSpace,
+	"trimRightSpace":          trimRightSpace,
+	"trimTrailingWhitespaces": trimRightSpace,
+	"rpad":                    rpad,
+}
+
+func trimRightSpace(s string) string {
+	return strings.TrimRightFunc(s, unicode.IsSpace)
+}
+
+// rpad adds padding to the right of a string.
+func rpad(s string, padding int) string {
+	template := fmt.Sprintf("%%-%ds", padding)
+	return fmt.Sprintf(template, s)
+}
+
+// tmpl executes the given template text on data, writing the result to w.
+func tmpl(w io.Writer, text string, data interface{}) error {
+	t := template.New("tmpl")
+	t.Funcs(templateFuncs)
+	template.Must(t.Parse(text))
+	return t.Execute(w, data)
+}
+
+// UsageTemplate returns usage template for the command.
+func UsageTemplate() string {
+	return `Usage:{{if .Cmd.Runnable}}
+  {{.Cmd.UseLine}}{{end}}{{if .Cmd.HasAvailableSubCommands}}
+  {{.Cmd.CommandPath}} [command]{{end}}{{if gt (len .Cmd.Aliases) 0}}
+
+Aliases:
+  {{.Cmd.NameAndAliases}}{{end}}{{if .Cmd.HasExample}}
+
+Examples:
+{{.Cmd.Example}}{{end}}
+
+Available Options:{{range .Opts }}
+  {{.Arguments}}	{{.Description}}{{end}}{{if .Cmd.HasAvailableLocalFlags}}
+
+Flags:
+{{.Cmd.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .Cmd.HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.Cmd.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .Cmd.HasHelpSubCommands}}
+
+Additional help topics:{{range .Cmd.Commands}}{{if .Cmd.IsAdditionalHelpTopicCommand}}
+  {{rpad .Cmd.CommandPath .Cmd.CommandPathPadding}} {{.Cmd.Short}}{{end}}{{end}}{{end}}{{if .Cmd.HasAvailableSubCommands}}
+
+Use "{{.Cmd.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+}
+
+// UsageFunc overrides the default UsageFunc used by Cobra to facilitate showing command options
+func UsageFunc(wrapper utils.CommandWrapper) (f func(*cobra.Command) error) {
+	return func(c *cobra.Command) error {
+		w := tabwriter.NewWriter(os.Stdout, 8, 8, 8, ' ', 0)
+		err := tmpl(w, UsageTemplate(), wrapper)
+		if err != nil {
+			c.PrintErrln(err)
+		}
+		w.Flush()
+		return err
+	}
+}


### PR DESCRIPTION
This PR overrides the Cobra `UsageFunc` and `UsageTemplate` for the `deploy` and `delete` commands.  Some small refactors and utils were created as a result.