### PR TITLE
abstracted much of main.go to kruise.go

### DIFF
--- a/cmd/kruise/main.go
+++ b/cmd/kruise/main.go
@@ -1,70 +1,11 @@
 package main
 
 import (
-	"fmt"
-	"log"
-	"os"
-
-	del "github.com/j2udevelopment/kruise/pkg/cli/delete"
-	dep "github.com/j2udevelopment/kruise/pkg/cli/deploy"
-	c "github.com/j2udevelopment/kruise/pkg/config"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/j2udevelopment/kruise/pkg/kruise"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-var configFile string
-var config c.Config
-
-// // Execute adds all child commands to the root command and sets flags appropriately.
-// // This is called by main.main(). It only needs to happen once to the kruiseCmd.
+// Simple main function that creates a new kruise command
 func main() {
-	cobra.CheckErr(NewKruiseCmd().Execute())
-}
-
-// NewCmd ...
-func NewKruiseCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "kruise",
-		Short: "Kruise streamlines the local development experience",
-		Long:  "Kruise is a CLI that aims to streamline the local development experience.\nModern software development can involve an overwhelming number of tools.\nYou can think of Kruise as a CLI wrapper that abstracts (but doesn't hide) the finer details of using many other CLIs that commonly make their way into a software engineers tool kit.",
-	}
-	cmd.AddCommand(
-		dep.NewDeployCmd(dep.NewDeployOpts()),
-		del.NewDeleteCmd(del.NewDeleteOpts()),
-	)
-	cmd.PersistentFlags().StringVar(&configFile, "config", "", "config file (default is $HOME/.kruise.yaml)")
-	return cmd
-}
-
-func init() {
-	cobra.OnInitialize(initConfig)
-}
-
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
-	if configFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(configFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory with name ".kruise" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName(".kruise")
-	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
-	err := viper.Unmarshal(&config)
-	if err != nil {
-		log.Fatalf("Unable to decode config into struct, %v", err)
-	}
+	cobra.CheckErr(kruise.NewKruiseCmd().Execute())
 }

--- a/pkg/kruise/delete/delete.go
+++ b/pkg/kruise/delete/delete.go
@@ -1,4 +1,4 @@
-package cli
+package delete
 
 import (
 	"sync"

--- a/pkg/kruise/deploy/deploy.go
+++ b/pkg/kruise/deploy/deploy.go
@@ -1,4 +1,4 @@
-package cli
+package deploy
 
 import (
 	"sync"

--- a/pkg/kruise/kruise.go
+++ b/pkg/kruise/kruise.go
@@ -1,0 +1,64 @@
+package kruise
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	c "github.com/j2udevelopment/kruise/pkg/config"
+	del "github.com/j2udevelopment/kruise/pkg/kruise/delete"
+	dep "github.com/j2udevelopment/kruise/pkg/kruise/deploy"
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var configFile string
+var config c.Config
+
+// NewKruiseCmd represents to root command of the kruise CLI
+func NewKruiseCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kruise",
+		Short: "Kruise streamlines the local development experience",
+		Long:  "Kruise is a CLI that aims to streamline the local development experience.\nModern software development can involve an overwhelming number of tools.\nYou can think of Kruise as a CLI wrapper that abstracts (but doesn't hide) the finer details of using many other CLIs that commonly make their way into a software engineers tool kit.",
+	}
+	cmd.AddCommand(
+		dep.NewDeployCmd(dep.NewDeployOpts()),
+		del.NewDeleteCmd(del.NewDeleteOpts()),
+	)
+	cmd.PersistentFlags().StringVar(&configFile, "config", "", "config file (default is $HOME/.kruise.yaml)")
+	return cmd
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if configFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(configFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		cobra.CheckErr(err)
+
+		// Search config in home directory with name ".kruise" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigType("yaml")
+		viper.SetConfigName(".kruise")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+	}
+	err := viper.Unmarshal(&config)
+	if err != nil {
+		log.Fatalf("Unable to decode config into struct, %v", err)
+	}
+}


### PR DESCRIPTION
Opting for a simpler entrypoint and giving users the option of importing the root kruise command.